### PR TITLE
fix: bug on images keys that have thumbor filters like names

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -185,8 +185,10 @@ class ImageRequest {
             return decoded.key;
         }
 
-        if (requestType === "Thumbor" || requestType === "Custom") {
-            return decodeURIComponent(event["path"].replace(/\d+x\d+\/|filters[:-][^/;]+|\/fit-in\/+|^\/+/g,'').replace(/^\/+/,''));
+        if (requestType === "Thumbor" || requestType === "Custom") {            
+            const splitPath = event['path'].split('/')
+            const encoded = splitPath[splitPath.length - 1]
+            return decodeURIComponent(encoded)
         }
 
         // Return an error for all other conditions

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -59,7 +59,7 @@ describe('setup()', function() {
             the ImageRequest object with the proper values`, async function() {
             // Arrange
             const event = {
-                path : "/filters:grayscale()/test-image-001-300x200.jpg"
+                path : "/filters:grayscale()/uploads%2Ftest-image-001-300x200.jpg"
             }
             process.env = {
                 SOURCE_BUCKETS : "allowedBucket001, allowedBucket002"
@@ -68,7 +68,7 @@ describe('setup()', function() {
             const S3 = require('aws-sdk/clients/s3');
             const sinon = require('sinon');
             const getObject = S3.prototype.getObject = sinon.stub();
-            getObject.withArgs({Bucket: 'allowedBucket001', Key: 'test-image-001-300x200.jpg'}).returns({
+            getObject.withArgs({Bucket: 'allowedBucket001', Key: 'uploads/test-image-001-300x200.jpg'}).returns({
                 promise: () => { return {
                     Body: Buffer.from('SampleImageContent\n')
                 }}
@@ -79,7 +79,7 @@ describe('setup()', function() {
             const expectedResult = {
                 requestType: 'Thumbor',
                 bucket: 'allowedBucket001',
-                key: 'test-image-001-300x200.jpg',
+                key: 'uploads/test-image-001-300x200.jpg',
                 edits: { grayscale: true },
                 originalImage: Buffer.from('SampleImageContent\n'),
                 CacheControl: 'max-age=31536000,public',

--- a/source/image-handler/test/test-image-request.js
+++ b/source/image-handler/test/test-image-request.js
@@ -59,7 +59,7 @@ describe('setup()', function() {
             the ImageRequest object with the proper values`, async function() {
             // Arrange
             const event = {
-                path : "/filters:grayscale()/test-image-001.jpg"
+                path : "/filters:grayscale()/test-image-001-300x200.jpg"
             }
             process.env = {
                 SOURCE_BUCKETS : "allowedBucket001, allowedBucket002"
@@ -68,7 +68,7 @@ describe('setup()', function() {
             const S3 = require('aws-sdk/clients/s3');
             const sinon = require('sinon');
             const getObject = S3.prototype.getObject = sinon.stub();
-            getObject.withArgs({Bucket: 'allowedBucket001', Key: 'test-image-001.jpg'}).returns({
+            getObject.withArgs({Bucket: 'allowedBucket001', Key: 'test-image-001-300x200.jpg'}).returns({
                 promise: () => { return {
                     Body: Buffer.from('SampleImageContent\n')
                 }}
@@ -79,7 +79,7 @@ describe('setup()', function() {
             const expectedResult = {
                 requestType: 'Thumbor',
                 bucket: 'allowedBucket001',
-                key: 'test-image-001.jpg',
+                key: 'test-image-001-300x200.jpg',
                 edits: { grayscale: true },
                 originalImage: Buffer.from('SampleImageContent\n'),
                 CacheControl: 'max-age=31536000,public',

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -30,11 +30,12 @@ class ThumborMapping {
     process(event) {
         // Setup
         this.path = event.path;
-        const edits = this.path.split('/');
+        const edits = this.path.split('/').slice(0, -1)
         const filetype = (this.path.split('.'))[(this.path.split('.')).length - 1];
 
         // Process the Dimensions
-        const dimPath = this.path.match(/[^\/]\d+x\d+/g);
+        const dimPath = edits.join('/').match(/[^\/]\d+x\d+/g)
+
         if (dimPath) {
             const dims = dimPath[0].split('x');
             // Set only if the dimensions provided are valid


### PR DESCRIPTION
If bucket image key/name contains a thumbor filter, it fails to process transformation

*Description of changes:*
Changed the way the keys are handled for thumbor requests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
