### PR TITLE
Allow custom requests for keys without file extensions

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -292,7 +292,6 @@ class ImageRequest {
         try {
             this.decodeRequest(event);
         } catch(error) {
-            console.error(error);
             isBase64Encoded = false;
         } 
 

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -279,7 +279,6 @@ class ImageRequest {
         const path = event["path"];
         const matchDefault = new RegExp(/^(\/?)([0-9a-zA-Z+\/]{4})*(([0-9a-zA-Z+\/]{2}==)|([0-9a-zA-Z+\/]{3}=))?$/);
         const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?)(((.(?!(\.[^.\\\/]+$)))*$)|.*(\.jpg$|.\.png$|\.webp$|\.tiff$|\.jpeg$|\.svg$))/i);
-        const matchCustom = new RegExp(/(\/?)(.*)(jpg|png|webp|tiff|jpeg|svg)/i);
         const definedEnvironmentVariables = (
             (process.env.REWRITE_MATCH_PATTERN !== "") &&
             (process.env.REWRITE_SUBSTITUTION !== "") &&

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -298,7 +298,7 @@ class ImageRequest {
 
         if (matchDefault.test(path) && isBase64Encoded) {  // use sharp
             return 'Default';
-        } else if (matchCustom.test(path) && definedEnvironmentVariables) {  // use rewrite function then thumbor mappings
+        } else if (definedEnvironmentVariables) {  // use rewrite function then thumbor mappings
             return 'Custom';
         } else if (matchThumbor.test(path)) {  // use thumbor mappings
             return 'Thumbor';


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
#268


**Description of changes:**
Removed the regex that explicitly checks for existence of a file extension with custom requests


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
