### PR TITLE
fix - overlaywith top/left return int after percent conversion

### DIFF
--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -103,7 +103,7 @@ class ImageHandler {
                                 left = imageMetadata.width + left - overlayMetadata.width;
                             }
                         }
-                        isNaN(left) ? delete options.left : options.left = left;
+                        isNaN(left) ? delete options.left : options.left = parseInt(left);
                     }
                     if (options.top !== undefined) {
                         let top = options.top;
@@ -120,7 +120,7 @@ class ImageHandler {
                                 top = imageMetadata.height + top - overlayMetadata.height;
                             }
                         }
-                        isNaN(top) ? delete options.top : options.top = top;
+                        isNaN(top) ? delete options.top : options.top = parseInt(top);
                     }
                 }
 


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
254


**Description of changes:**
<!-- Please describe the changes you made -->
convert left and top to int after percentage based calculation which can potentially return float which throws an error.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
