### PR TITLE
Use Buffer.byteLength instead of length

### DIFF
--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -44,8 +44,8 @@ class ImageHandler {
         }
 
         // If the converted image is larger than Lambda's payload hard limit, throw an error.
-        const lambdaPayloadLimit = 6 * 1024 * 1024;
-        if (returnImage.length > lambdaPayloadLimit) {
+        const lambdaPayloadLimit = 6291456; // 6 * 1024 * 1024
+        if (Buffer.byteLength(returnImage, 'base64' ) > lambdaPayloadLimit) {
             throw {
                 status: '413',
                 code: 'TooLargeImageException',


### PR DESCRIPTION
Use `Buffer.byteLength` instead of just getting the length of a base64 encoded string. `Buffer.byteLength` is more accurate since base64 strings need to add padding in order to arrive at the appropriate length.

**Issue #, if available:**
#282


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
