### PR TITLE
make webp reduction effort a configurable

### DIFF
--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -33,6 +33,13 @@ class ImageHandler {
                 }
             }
 
+            if (request.outputFormat === 'webp') {
+                const reductionEffortVal = process.env.WEBP_REDUCTION_EFFORT;
+                if (typeof reductionEffortVal !== "undefined") {
+                    image = sharp(originalImage, { failOnError: false }).webp({reductionEffort: parseInt(reductionEffortVal, 10)});
+                }
+            }
+            
             const modifiedImage = await this.applyEdits(image, edits);
             if (request.outputFormat !== undefined) {
                 modifiedImage.toFormat(request.outputFormat);


### PR DESCRIPTION

**Issue #, if available:**
Resolves #289

**Description of changes:**
allows you to set an environment variable WEBP_REDUCTION_EFFORT to configure the amount of effort that is put into webp reducing size. trade off is more cpu effort ($$$) vs file size



**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
