### PR TITLE
support object key with characters need to be URI encoded

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -237,7 +237,7 @@ class ImageRequest {
         if (requestType === "Default") {
             // Decode the image request and return the image key
             const decoded = this.decodeRequest(event);
-            return decoded.key;
+            return decodeURIComponent(decoded.key);
         }
 
         if (requestType === "Thumbor" || requestType === "Custom") {

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -533,6 +533,41 @@ describe('setup()', function() {
             expect(imageRequest).toEqual(expectedResult);
         });
     });
+    describe('010/defaultImageRequest/WithUriEncodedKey', function() {
+        it('Should pass when a default image request is provided and populate the ImageRequest object with the proper values and a URI encoded key', async function() {
+            // Arrange
+            const event = {
+                path : '/eyJidWNrZXQiOiJ2YWxpZEJ1Y2tldCIsImtleSI6IiVFNCVCOCVBRCVFNiU5NiU4NyIsImVkaXRzIjp7ImdyYXlzY2FsZSI6dHJ1ZX0sIm91dHB1dEZvcm1hdCI6ImpwZWcifQ=='
+            }
+            process.env = {
+                SOURCE_BUCKETS : "validBucket, validBucket2"
+            }
+            // Mock
+            mockAws.getObject.mockImplementationOnce(() => {
+                return {
+                    promise() {
+                        return Promise.resolve({ Body: Buffer.from('SampleImageContent\n') });
+                    }
+                };
+            });
+            // Act
+            const imageRequest = new ImageRequest(s3, secretsManager);
+            await imageRequest.setup(event);
+            const expectedResult = {
+                requestType: 'Default',
+                bucket: 'validBucket',
+                key: '中文',
+                edits: { grayscale: true },
+                outputFormat: 'jpeg',
+                originalImage: Buffer.from('SampleImageContent\n'),
+                CacheControl: 'max-age=31536000,public',
+                ContentType: 'image/jpeg'
+            };
+            // Assert
+            expect(mockAws.getObject).toHaveBeenCalledWith({ Bucket: 'validBucket', Key: '中文' });
+            expect(imageRequest).toEqual(expectedResult);
+        });
+    });
 });
 // ----------------------------------------------------------------------------
 // getOriginalImage()


### PR DESCRIPTION
**Description of changes:**
URI decode the parsed object key in ImageRequest class.
The change can cause missing image if the key existing on S3 is intentionally URI encoded. e.g. If the key of the object stored on S3 is `%E4%B8%AD%E6%96%87.jpg`, this change will cause the handler to look for object with the key `中文.jpg`. The key in the request would have to be double URI decoded (`%25E4%25B8%25AD%25E6%2596%2587.jpg`) to access that object.


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [x] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
