### PR TITLE
chore: added close inactive issues GitHub workflow

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-issue-stale: 180
+          days-before-issue-close: 7
+          stale-issue-label: closing-soon
+          stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+          close-issue-message: This issue was closed because it has been inactive for 7 days since being marked as closing-soon.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description of changes:**
<!-- Please describe the changes you made -->
Adding `close_inactive_issues.yml` to close inactive issues automatically.
All inactive issues older than 180 days would be labeled as `closing-soon`. After 7 days after the `closing-soon` label, if issues are still inactive, it would be automatically closed.

This only happens for issues. Pull requests would be managed manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
