### PR TITLE
Improve CloudFront cache hit ratio

### DIFF
--- a/source/constructs/lib/back-end/back-end-construct.ts
+++ b/source/constructs/lib/back-end/back-end-construct.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LambdaRestApiProps, RestApi } from '@aws-cdk/aws-apigateway';
-import { AllowedMethods, CachePolicy, DistributionProps, IOrigin, OriginRequestPolicy, OriginSslPolicy, PriceClass, ViewerProtocolPolicy } from '@aws-cdk/aws-cloudfront';
+import { AllowedMethods, CacheHeaderBehavior, CachePolicy, DistributionProps, IOrigin, OriginRequestPolicy, OriginSslPolicy, PriceClass, ViewerProtocolPolicy } from '@aws-cdk/aws-cloudfront';
 import { HttpOrigin } from '@aws-cdk/aws-cloudfront-origins';
 import { Policy, PolicyStatement, Role, ServicePrincipal } from '@aws-cdk/aws-iam';
 import { Code, Function as LambdaFunction, Runtime } from '@aws-cdk/aws-lambda';
@@ -108,10 +108,7 @@ export class BackEnd extends Construct {
 
     const originRequestPolicy = new OriginRequestPolicy(this, 'OriginRequestPolicy', {
       originRequestPolicyName: `ServerlessImageHandler-${props.uuid}`,
-      headerBehavior: {
-        behavior: 'whitelist',
-        headers: ['origin', 'accept']
-      },
+      headerBehavior: props.autoWebP == "Yes" ? CacheHeaderBehavior.allowList('origin', 'accept') : CacheHeaderBehavior.none(),
       queryStringBehavior: {
         behavior: 'whitelist',
         queryStrings: ['signature']


### PR DESCRIPTION

**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
https://github.com/aws-solutions/serverless-image-handler/issues/304



**Description of changes:**
<!-- Please describe the changes you made -->

There's no need to include in the cache key the `origin` and `accept` http headers if `AutoWebP` is disabled.

This improves the cache hit ratio if `AutoWebP` is not used.


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
