### PR TITLE
Add RetentionDays.INFINITE

### DIFF
--- a/source/constructs/lib/serverless-image-stack.ts
+++ b/source/constructs/lib/serverless-image-stack.ts
@@ -55,7 +55,7 @@ export class ServerlessImageHandlerStack extends Stack {
     const logRetentionPeriodParameter = new CfnParameter(this, 'LogRetentionPeriodParameter', {
       type: 'Number',
       description: 'This solution automatically logs events to Amazon CloudWatch. Select the amount of time for CloudWatch logs from this solution to be retained (in days).',
-      allowedValues: ['1', '3', '5', '7', '14', '30', '60', '90', '120', '150', '180', '365', '400', '545', '731', '1827', '3653'],
+      allowedValues: ['1', '3', '5', '7', '14', '30', '60', '90', '120', '150', '180', '365', '400', '545', '731', '1827', '3653', '9999'],
       default: '1'
     });
 

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -298,6 +298,7 @@ Object {
         "731",
         "1827",
         "3653",
+        "9999",
       ],
       "Default": "1",
       "Description": "This solution automatically logs events to Amazon CloudWatch. Select the amount of time for CloudWatch logs from this solution to be retained (in days).",


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

None

**Description of changes:**
<!-- Please describe the changes you made -->

According to the documentation, the value 9999 exists, so we should be able to use it.
See https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-logs.RetentionDays.html

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
