### PR TITLE
Disabling gzip compression in cloudfront's cache option.

### DIFF
--- a/source/constructs/lib/back-end/back-end-construct.ts
+++ b/source/constructs/lib/back-end/back-end-construct.ts
@@ -140,7 +140,7 @@ export class BackEnd extends Construct {
       defaultTtl: Duration.days(1),
       minTtl: Duration.seconds(1),
       maxTtl: Duration.days(365),
-      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingGzip: false,
       headerBehavior: CacheHeaderBehavior.allowList("origin", "accept"),
       queryStringBehavior: CacheQueryStringBehavior.allowList("signature"),
     });

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -395,7 +395,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
               "CookieBehavior": "none",
             },
             "EnableAcceptEncodingBrotli": false,
-            "EnableAcceptEncodingGzip": true,
+            "EnableAcceptEncodingGzip": false,
             "HeadersConfig": {
               "HeaderBehavior": "whitelist",
               "Headers": [


### PR DESCRIPTION
There's no need to enable gzip in the cloudfront's cache policy.  
  
Current cache policy, enables gzip compression which in turn adds the "accept-encoding" header to the cache key. But origin (resizing lambda) won't use it (am I missing something?) which makes sense because we are working with already compressed image-formats.  
_Notice that cloudfront enables auto compression only on image/svg+xml (see [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html)) which also makes sense._  
So, with current cache policy, two almost "equivalent" requests (from cloudfront's cache key perspective), except for the accept-encoding: gzip header presence, will generate different entries on the cache.  
  
Please read this: ["Remove Accept-Encoding header when compression is not needed"](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cache-hit-ratio.html#cache-hit-ratio-remove-accept-encoding).  
  
I am disabling gzip compression on cloudfront's cache policy. This change will improve the cloudfront's cache hit ratio. 

**Issue #, if available:**

#304

**Description of changes:**

Switching off gzip compression on cloudfront's cache policy.  
  
Tests were updated to reflect changes.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
