### PR TITLE
Add support for HTTPS image origin

### DIFF
--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "color": "3.1.3",
     "color-name": "1.1.4",
-    "sharp": "^0.27.0"
+    "sharp": "^0.29.0"
   },
   "devDependencies": {
     "@types/color": "^3.0.2",


### PR DESCRIPTION
## Description

PR for ticket: [Fork Serverless Image Handler, add support for HTTPS image origins](https://github.com/milliononmars/mom-dot-com/issues/3653)