### PR TITLE
Backend Image Handler Lambda Function - Timeout following API Gateway

### DIFF
--- a/source/constructs/lib/back-end/back-end-construct.ts
+++ b/source/constructs/lib/back-end/back-end-construct.ts
@@ -89,7 +89,7 @@ export class BackEnd extends Construct {
       description: `${props.solutionName} (${props.solutionVersion}): Performs image edits and manipulations`,
       memorySize: 1024,
       runtime: Runtime.NODEJS_16_X,
-      timeout: Duration.minutes(15),
+      timeout: Duration.seconds(29),
       role: imageHandlerLambdaFunctionRole,
       entry: path.join(__dirname, "../../../image-handler/index.ts"),
       environment: {

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -1205,7 +1205,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
             "Value": "S0ABC",
           },
         ],
-        "Timeout": 900,
+        "Timeout": 29,
       },
       "Type": "AWS::Lambda::Function",
     },


### PR DESCRIPTION
Backend Image Handler Lambda Function construct (CDK) has a timeout of `timeout: Duration.minutes(15)`.
It makes no sense to continue executing the lambda after 29 seconds since Api Gateway on front will have replied to CloudFront with a 504 status code (Gateway Timeout).
Notice: read about Api Gateway integrations [limits](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) with Lambda.

Issue #, if available: #379

**Description of changes:**
Backend Image Handler Lambda Function construct (CDK) configured with `timeout: Duration.seconds(29)`.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
