### PR TITLE
Enable HTTP/3 on CloudFront endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ demo-ui-config.js
 # System Files
 **/.DS_Store
 **/.vscode
+**/.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ demo-ui-config.js
 # System Files
 **/.DS_Store
 **/.vscode
+**/*.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ demo-ui-config.js
 # System Files
 **/.DS_Store
 **/.vscode
-**/.sublime-*

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -507,7 +507,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
             "ViewerProtocolPolicy": "https-only",
           },
           "Enabled": true,
-          "HttpVersion": "http2",
+          "HttpVersion": "http2_and_3",
           "IPV6Enabled": true,
           "Logging": {
             "Bucket": {
@@ -1866,7 +1866,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
-          "HttpVersion": "http2",
+          "HttpVersion": "http2_and_3",
           "IPV6Enabled": true,
           "Logging": {
             "Bucket": {


### PR DESCRIPTION
**Issue #, if available:**
No issues, just improvements.

**Description of changes:**
Enable HTTP/3 on CloudFront endpoints. As there are no downsides to it, there is no reason to skip it by default.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
