### PR TITLE
fix(demo-ui): demo UI unicode support

### DIFF
--- a/source/demo-ui/scripts.js
+++ b/source/demo-ui/scripts.js
@@ -18,7 +18,7 @@ function importOriginalImage() {
     // Assemble the image request
     const request = {
         bucket: bucketName,
-        key: keyName
+        key: encodeURIComponent(keyName)
     }
     const strRequest = JSON.stringify(request);
     const encRequest = btoa(strRequest);
@@ -77,7 +77,7 @@ function getPreviewImage() {
     // Set up the request body
     const request = {
         bucket: bucketName,
-        key: keyName,
+        key: encodeURIComponent(keyName),
         edits: _edits
     }
     if (Object.keys(request.edits).length === 0) { delete request.edits }

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -443,7 +443,7 @@ export class ImageHandler {
     alpha: string,
     sourceImageMetadata: sharp.Metadata
   ): Promise<Buffer> {
-    const params = { Bucket: bucket, Key: key };
+    const params = { Bucket: bucket, Key: decodeURIComponent(key) };
     try {
       const { width, height } = sourceImageMetadata;
       const overlayImage: S3.GetObjectOutput = await this.s3Client.getObject(params).promise();

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -269,7 +269,7 @@ export class ImageRequest {
     if (requestType === RequestTypes.DEFAULT) {
       // Decode the image request and return the image key
       const { key } = this.decodeRequest(event);
-      return key;
+      return decodeURIComponent(key);
     }
 
     if (requestType === RequestTypes.THUMBOR || requestType === RequestTypes.CUSTOM) {


### PR DESCRIPTION
**Issue #, if available:**
#416 Add unicode support to demo-ui to enable the use of keys containing unicode characters

This was an issue discovered by @batica81 where the demo-ui component of SIH did not support image keys containing unicode characters. The initial suggested fix included the use of a deprecated function.
The fixes contained in this PR were suggested by @fisenkodv did not use the deprecated function and tested successfully.

While testing, it was discovered that the use of watermark (overlay) images also did not support unicode characters in the backend which has been resolved in this PR.


**Description of changes:**
* scripts (front-end) encode key in request using encodeURIComponent
* image-request (backend) decode key using decodeURIComponent  when request received
* image-handler (backend) decode key for watermark

Tested using combinations of keys with both ascii and unicode characters for both image and watermark keys.

Example test request bodies:
* unicode key (sharp style after base64 -d):
```json
  {"bucket":"test-bucket","key":"Västerås.jpeg","edits":{"contentModeration":{"minConfidence":90,"blur":100,"moderationLabels":["Gambling"]}}}
```
* ascii key, unicode watermark (thumbor style):
  * https://cloudfront/filters:watermark(test-bucket,Va%CC%88stera%CC%8As.jpeg,50,50,0,25,50)/image.jpg
* unicode key. unicode watermark:
  * https://cloudfront/filters:watermark(test-bucket,Va%CC%88stera%CC%8As.jpeg,50,50,0,25,50)/čćšđ_unicode_test.jpg

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
