### PR TITLE
feat(rewrite-pattern): rewrite pattern substitution support with unit tests

### DIFF
--- a/deployment/run-unit-tests.sh
+++ b/deployment/run-unit-tests.sh
@@ -53,6 +53,7 @@ declare -a lambda_packages=(
   "constructs"
   "image-handler"
   "custom-resource"
+  "solution-utils"
 )
 
 export overrideWarningsEnabled=false

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -278,15 +278,18 @@ export class ImageRequest {
       if (requestType === RequestTypes.CUSTOM) {
         const { REWRITE_MATCH_PATTERN, REWRITE_SUBSTITUTION } = process.env;
 
-        if (typeof REWRITE_MATCH_PATTERN === "string") {
-          const patternStrings = REWRITE_MATCH_PATTERN.split("/");
-          const flags = patternStrings.pop();
-          const parsedPatternString = REWRITE_MATCH_PATTERN.slice(1, REWRITE_MATCH_PATTERN.length - 1 - flags.length);
-          const regExp = new RegExp(parsedPatternString, flags);
+        const REWRITE_MATCH_PATTERNS = this.parseJson(REWRITE_MATCH_PATTERN);
+        const REWRITE_SUBSTITUTIONS = this.parseJson(REWRITE_SUBSTITUTION);
 
-          path = path.replace(regExp, REWRITE_SUBSTITUTION);
-        } else {
-          path = path.replace(REWRITE_MATCH_PATTERN, REWRITE_SUBSTITUTION);
+        for (let k = 0; k < REWRITE_MATCH_PATTERNS.length; k++) {
+          let matchPattern = REWRITE_MATCH_PATTERNS[k]
+          if (typeof (matchPattern) === 'string') {
+            let regExp = this.generateRegExp(matchPattern);
+            path = path.replace(regExp, REWRITE_SUBSTITUTIONS[k]);
+            if (this.generateRegExp(matchPattern).test(path)) break;
+          } else {
+            path = path.replace(matchPattern, REWRITE_SUBSTITUTIONS[k]);
+          }
         }
       }
 
@@ -303,6 +306,20 @@ export class ImageRequest {
     );
   }
 
+  parseJson(str) {
+    try {
+      return JSON.parse(str);
+    } catch (e) {
+      return [str];
+    }
+  }
+
+  generateRegExp(matchPattern) {
+    const patternStrings = matchPattern.split('/');
+    const flags = patternStrings.pop();
+    const parsedPatternString = matchPattern.slice(1, matchPattern.length - 1 - flags.length);
+    return new RegExp(parsedPatternString, flags);
+  }
   /**
    * Determines how to handle the request being made based on the URL path prefix to the image request.
    * Categorizes a request as either "image" (uses the Sharp library), "thumbor" (uses Thumbor mapping), or "custom" (uses the rewrite function).

--- a/source/image-handler/test/image-request/parse-image-key.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-key.spec.ts
@@ -240,6 +240,27 @@ describe("parseImageKey", () => {
     expect(result).toEqual(expectedResult);
   });
 
+  it("Should pass if an image key value is provided in the custom request format - confirm key retrieval when multiple image rewrite specified", () => {
+    // Arrange
+    const event = {
+      path: "/thumb/test.jpg",
+    };
+
+    process.env = {
+      REWRITE_MATCH_PATTERN: '["//thumb/g","//small/g","//large/g"]',
+      REWRITE_SUBSTITUTION:
+        '["/300x300/filters:quality(80)","/fit-in/600x600/filters:quality(80)","/fit-in/1200x1200/filters:quality(80)"]',
+    };
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.parseImageKey(event, RequestTypes.CUSTOM);
+
+    // Assert
+    const expectedResult = "test.jpg";
+    expect(result).toEqual(expectedResult);
+  });
+
   it("Should throw an error if an unrecognized requestType is passed into the function as a parameter", () => {
     // Arrange
     const event = {

--- a/source/image-handler/test/image-request/parse-request-type.spec.ts
+++ b/source/image-handler/test/image-request/parse-request-type.spec.ts
@@ -88,6 +88,24 @@ describe("parseRequestType", () => {
     expect(result).toEqual(expectedResult);
   });
 
+  it("Should pass if the method detects a custom request with multiple rewrite patterns", () => {
+    // Arrange
+    const event = { path: "/additionalImageRequestParameters/image.jpg" };
+    process.env = {
+      REWRITE_MATCH_PATTERN: '["//thumb/g","//small/g","//large/g"]',
+      REWRITE_SUBSTITUTION:
+        '["/300x300/filters:quality(80)","/fit-in/600x600/filters:quality(80)","/fit-in/1200x1200/filters:quality(80)"]',
+    };
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.parseRequestType(event);
+
+    // Assert
+    const expectedResult = RequestTypes.CUSTOM;
+    expect(result).toEqual(expectedResult);
+  });
+
   it("Should throw an error if the method cannot determine the request type based on the three groups given", () => {
     // Arrange
     const event = { path: "12x12e24d234r2ewxsad123d34r.bmp" };

--- a/source/image-handler/thumbor-mapper.ts
+++ b/source/image-handler/thumbor-mapper.ts
@@ -5,6 +5,7 @@ import Color from "color";
 import ColorName from "color-name";
 
 import { ImageEdits, ImageFitTypes, ImageFormatTypes } from "./lib";
+import { parseJson, generateRegExp } from "../solution-utils/helpers";
 
 export class ThumborMapper {
   private static readonly EMPTY_IMAGE_EDITS: ImageEdits = {};
@@ -54,15 +55,15 @@ export class ThumborMapper {
     } else {
       let parsedPath = "";
 
-      const REWRITE_MATCH_PATTERNS = this.parseJson(REWRITE_MATCH_PATTERN);
-      const REWRITE_SUBSTITUTIONS = this.parseJson(REWRITE_SUBSTITUTION);
+      const REWRITE_MATCH_PATTERNS = parseJson(REWRITE_MATCH_PATTERN);
+      const REWRITE_SUBSTITUTIONS = parseJson(REWRITE_SUBSTITUTION);
 
       for (let k = 0; k < REWRITE_MATCH_PATTERNS.length; k++) {
-        let matchPattern = REWRITE_MATCH_PATTERNS[k]
-        if (typeof (matchPattern) === 'string') {
-          let regExp = this.generateRegExp(matchPattern);
+        const matchPattern = REWRITE_MATCH_PATTERNS[k];
+        if (typeof matchPattern === "string") {
+          const regExp = generateRegExp(matchPattern);
           parsedPath = path.replace(regExp, REWRITE_SUBSTITUTIONS[k]);
-          if (this.generateRegExp(matchPattern).test(path)) break;
+          if (generateRegExp(matchPattern).test(path)) break;
         } else {
           parsedPath = path.replace(matchPattern, REWRITE_SUBSTITUTIONS[k]);
         }
@@ -71,20 +72,7 @@ export class ThumborMapper {
       return parsedPath;
     }
   }
-  parseJson(str) {
-    try {
-      return JSON.parse(str);
-    } catch (e) {
-      return [str];
-    }
-  }
 
-  generateRegExp(matchPattern) {
-    const patternStrings = matchPattern.split('/');
-    const flags = patternStrings.pop();
-    const parsedPatternString = matchPattern.slice(1, matchPattern.length - 1 - flags.length);
-    return new RegExp(parsedPatternString, flags);
-  }
   /**
    * Maps background color the current edits object
    * @param filterValue The specified color value

--- a/source/image-handler/thumbor-mapper.ts
+++ b/source/image-handler/thumbor-mapper.ts
@@ -54,20 +54,37 @@ export class ThumborMapper {
     } else {
       let parsedPath = "";
 
-      if (typeof REWRITE_MATCH_PATTERN === "string") {
-        const patternStrings = REWRITE_MATCH_PATTERN.split("/");
-        const flags = patternStrings.pop();
-        const parsedPatternString = REWRITE_MATCH_PATTERN.slice(1, REWRITE_MATCH_PATTERN.length - 1 - flags.length);
-        const regExp = new RegExp(parsedPatternString, flags);
-        parsedPath = path.replace(regExp, REWRITE_SUBSTITUTION);
-      } else {
-        parsedPath = path.replace(REWRITE_MATCH_PATTERN, REWRITE_SUBSTITUTION);
+      const REWRITE_MATCH_PATTERNS = this.parseJson(REWRITE_MATCH_PATTERN);
+      const REWRITE_SUBSTITUTIONS = this.parseJson(REWRITE_SUBSTITUTION);
+
+      for (let k = 0; k < REWRITE_MATCH_PATTERNS.length; k++) {
+        let matchPattern = REWRITE_MATCH_PATTERNS[k]
+        if (typeof (matchPattern) === 'string') {
+          let regExp = this.generateRegExp(matchPattern);
+          parsedPath = path.replace(regExp, REWRITE_SUBSTITUTIONS[k]);
+          if (this.generateRegExp(matchPattern).test(path)) break;
+        } else {
+          parsedPath = path.replace(matchPattern, REWRITE_SUBSTITUTIONS[k]);
+        }
       }
 
       return parsedPath;
     }
   }
+  parseJson(str) {
+    try {
+      return JSON.parse(str);
+    } catch (e) {
+      return [str];
+    }
+  }
 
+  generateRegExp(matchPattern) {
+    const patternStrings = matchPattern.split('/');
+    const flags = patternStrings.pop();
+    const parsedPatternString = matchPattern.slice(1, matchPattern.length - 1 - flags.length);
+    return new RegExp(parsedPatternString, flags);
+  }
   /**
    * Maps background color the current edits object
    * @param filterValue The specified color value

--- a/source/image-handler/tsconfig.json
+++ b/source/image-handler/tsconfig.json
@@ -10,6 +10,6 @@
     "sourceMap": true,
     "types": ["node", "@types/jest"]
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "../solution-utils/test/helpers.spec.ts"],
   "exclude": ["package", "dist", "**/*.map"]
 }

--- a/source/solution-utils/helpers.ts
+++ b/source/solution-utils/helpers.ts
@@ -9,3 +9,28 @@
 export function isNullOrWhiteSpace(str: string): boolean {
   return !str || str.replace(/\s/g, "") === "";
 }
+
+/**
+ * Determine if this appears to be json or a plain string
+ * @param str Input string to evaluate
+ * @returns Either a json object or a plain string
+ */
+export function parseJson(str) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return [str];
+  }
+}
+
+/**
+ * Given a string that may describe actions in an image request, create a regex from the string
+ * @param matchPattern string to operate on
+ * @returns regex
+ */
+export function generateRegExp(matchPattern) {
+  const patternStrings = matchPattern.split("/");
+  const flags = patternStrings.pop();
+  const parsedPatternString = matchPattern.slice(1, matchPattern.length - 1 - flags.length);
+  return new RegExp(parsedPatternString, flags);
+}

--- a/source/solution-utils/test/get-options.test.ts
+++ b/source/solution-utils/test/get-options.test.ts
@@ -24,6 +24,7 @@ describe("getOptions", () => {
   });
 
   it("will return an empty object when environment variables are missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { getOptions } = require("../get-options");
     expect.assertions(4);
 
@@ -42,6 +43,7 @@ describe("getOptions", () => {
   });
 
   it("will return an object with the custom user agent string", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { getOptions } = require("../get-options");
     expect.assertions(1);
     expect(getOptions()).toEqual({

--- a/source/solution-utils/test/helpers.spec.ts
+++ b/source/solution-utils/test/helpers.spec.ts
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isNullOrWhiteSpace, parseJson, generateRegExp } from "../helpers";
+
+describe("helpers", () => {
+  it("Should pass if the proper result is returned for a whitespace only string", () => {
+    const result = isNullOrWhiteSpace(" ");
+
+    const expectedResult = true;
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for a null string", () => {
+    const result = isNullOrWhiteSpace("");
+
+    const expectedResult = true;
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for non-whitespace containing string", () => {
+    const result = isNullOrWhiteSpace("abc");
+
+    const expectedResult = false;
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for a singe entry", () => {
+    const result = parseJson("filter:");
+
+    const expectedResult = ["filter:"];
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for a null string", () => {
+    const result = parseJson("");
+
+    const expectedResult = [""];
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for json with multiple objects", () => {
+    const result = parseJson('["//thumb/g","//small/g","//large/g"]');
+
+    const expectedResult = ["//thumb/g", "//small/g", "//large/g"];
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if the proper result is returned for a simple regex", () => {
+    const result = generateRegExp("/thumb/g");
+
+    const expectedResult1 = /thumb/g;
+    expect(result).toEqual(expectedResult1);
+  });
+
+  it("Should pass if the proper result is returned for a simple rege with embedded slash that must be escaped", () => {
+    const result = generateRegExp("//thumb/g");
+
+    const expectedResult1 = /\/thumb/g;
+    expect(result).toEqual(expectedResult1);
+  });
+});

--- a/source/solution-utils/tsconfig.json
+++ b/source/solution-utils/tsconfig.json
@@ -10,6 +10,6 @@
     "sourceMap": true,
     "types": ["node", "@types/jest"]
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "test/helpers.spec.ts"],
   "exclude": ["package", "dist", "**/*.map"]
 }


### PR DESCRIPTION
**Description of changes:**
Add unit tests to rewrite pattern support from original PR #399 

All changes, including original:
* image-request and thumbor-mapper changes for multiple rewrite/substitution entries
* unit tests added for rewrite/substitution entries
* common functions in PR moved to solution-utils/helpers
* unit test support added for solution-utils/helpers

Serverless Image Handler provides support for remapping requests to reduce the effort required to migrate an existing image request model to the solution. This is done by configuring the REWRITE_MATCH_PATTERN and REWRITE_SUBSTITUTION regular expression environment variables for the backend Lambda. REWRITE_MATCH_PATTERN describes the incoming request that is to be changed. REWRITE_SUBSTITUTION contains the pattern to be mapped to. 

The initial implementation of this facility supported a single rewrite/substitution pair.
This PR provides the ability to remap/substitute multiple patterns.
The env vars are set to a matching set of entries.

REWRITE_MATCH_PATTERN and REWRITE_SUBSTITUTION values can be written like JSON Arrays so multiple rewrite rules can be applied.

For example, for the following env var in the. backend Lambda, 3 request patterns can be specified which will be mapped to the rewrite substitution values

REWRITE_MATCH_PATTERN:
["//thumb/g","//small/g","//large/g"]

REWRITE_SUBSTITUTION:
["/300x300/filters:quality(80)","/fit-in/600x600/filters:quality(80)","/fit-in/1200x1200/filters:quality(80)"]

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
