### PR TITLE
fix(thumbor): allow watermarks in folders for thumbor requests

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -291,7 +291,12 @@ export class ImageRequest {
       }
 
       return decodeURIComponent(
-        path.replace(/\/\d+x\d+:\d+x\d+\/|(?<=\/)\d+x\d+\/|filters:[^/]+|\/fit-in(?=\/)|^\/+/g, "").replace(/^\/+/, "")
+        path
+          .replace(
+            /\/\d+x\d+:\d+x\d+\/|(?<=\/)\d+x\d+\/|filters:watermark\(.*\)|filters:[^/]+|\/fit-in(?=\/)|^\/+/g,
+            ""
+          )
+          .replace(/^\/+/, "")
       );
     }
 

--- a/source/image-handler/test/image-request/parse-image-key.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-key.spec.ts
@@ -261,4 +261,34 @@ describe("parseImageKey", () => {
       });
     }
   });
+
+  it("Should pass if an image key value is provided in the thumbor request format with a watermark containing a slash", () => {
+    // Arrange
+    const event = {
+      path: "/fit-in/400x400/filters:watermark(bucket,folder/key.png,0,0)/image.jpg",
+    };
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.parseImageKey(event, RequestTypes.THUMBOR);
+
+    // Assert
+    const expectedResult = "image.jpg";
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("Should pass if an image key value is provided in the thumbor request format with a watermark not containing a slash", () => {
+    // Arrange
+    const event = {
+      path: "/fit-in/400x400/filters:watermark(bucket,key.png,0,0)/image.jpg",
+    };
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.parseImageKey(event, RequestTypes.THUMBOR);
+
+    // Assert
+    const expectedResult = "image.jpg";
+    expect(result).toEqual(expectedResult);
+  });
 });

--- a/source/image-handler/test/thumbor-mapper/filter.spec.ts
+++ b/source/image-handler/test/thumbor-mapper/filter.spec.ts
@@ -638,4 +638,68 @@ describe("filter", () => {
     };
     expect(edits).toEqual(expectedResult.edits);
   });
+
+  it("Should pass for fit-in combined with watermark in folder", () => {
+    // watermark params: bucket, key, xPos, yPos, alpha, wRatio, hRatio
+    const path = "/fit-in/400x400/filters:watermark(bucket,folder/key.png,0,0)/image.jpg";
+
+    // Act
+    const thumborMapper = new ThumborMapper();
+    const edits = thumborMapper.mapPathToEdits(path);
+
+    // Assert
+    const expectedResult = {
+      edits: {
+        resize: {
+          width: 400,
+          height: 400,
+          fit: "inside",
+        },
+        overlayWith: {
+          bucket: "bucket",
+          key: "folder/key.png",
+          alpha: undefined,
+          wRatio: undefined,
+          hRatio: undefined,
+          options: {
+            left: "0",
+            top: "0",
+          },
+        },
+      },
+    };
+    expect(edits).toEqual(expectedResult.edits);
+  });
+
+  it("Should pass for fit-in combined with watermark not in folder", () => {
+    // watermark params: bucket, key, xPos, yPos, alpha, wRatio, hRatio
+    const path = "/fit-in/400x400/filters:watermark(bucket,key.png,0,0)/image.jpg";
+
+    // Act
+    const thumborMapper = new ThumborMapper();
+    const edits = thumborMapper.mapPathToEdits(path);
+
+    // Assert
+    const expectedResult = {
+      edits: {
+        resize: {
+          width: 400,
+          height: 400,
+          fit: "inside",
+        },
+        overlayWith: {
+          bucket: "bucket",
+          key: "key.png",
+          alpha: undefined,
+          wRatio: undefined,
+          hRatio: undefined,
+          options: {
+            left: "0",
+            top: "0",
+          },
+        },
+      },
+    };
+    expect(edits).toEqual(expectedResult.edits);
+  });
 });


### PR DESCRIPTION
thumbor style requests including a watermark in a folder failed with watermark key not found error.
The parseImageKey regex failed to detect the watermark key correctly due to the embedded slash.
This changes the regex to detect the watermark correctly and includes new unit tests for that case.

Example thumbor style request with watermark in folder/key.png:
```/fit-in/400x400/filters:watermark(bucket,folder/key.png,0,0)/image.jpg```

**Description of changes:**
* image-request/parseImageKey regex addition for watermark inclusion
* unit tests for image-request, thumbor-mapper to verify watermarks with and without folder


**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
