### PR TITLE
fix(image-request): jpeg magic number FFD8FFED

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -445,6 +445,7 @@ export class ImageRequest {
         return ContentTypes.PNG;
       case "FFD8FFDB":
       case "FFD8FFE0":
+      case "FFD8FFED":
       case "FFD8FFEE":
       case "FFD8FFE1":
         return ContentTypes.JPEG;

--- a/source/image-handler/test/image-request/infer-image-type.spec.ts
+++ b/source/image-handler/test/image-request/infer-image-type.spec.ts
@@ -24,6 +24,18 @@ describe("inferImageType", () => {
     expect(result).toEqual("image/jpeg");
   });
 
+  it('Should pass if it returns "image/jpeg for a magic number of FFD8FFED"', () => {
+    // Arrange
+    const imageBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.inferImageType(imageBuffer);
+
+    // Assert
+    expect(result).toEqual("image/jpeg");
+  });
+
   it("Should pass throw an exception", () => {
     // Arrange
     const imageBuffer = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);


### PR DESCRIPTION
Some jpeg images include the magic number FFD8FFED in the header which was not supported resulting in the error

```{"status":500,"code":"RequestTypeError","message":"The file does not have an extension and the file type could not be inferred. Please ensure that your original image is of a supported file type (jpg, png, tiff, webp, svg). Refer to the documentation for additional guidance on forming image requests."}```

**Issue #, if available:**
#429 Add support for another jpeg magic number

**Description of changes:**
* image-request - added jpeg magic number FFD8FFED for inferImageType
* added unit test for new magic number

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
