### PR TITLE
Use stack name in Service Catalog Application name for multiple cfn stack deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - package-lock.json for all modules [#426](https://github.com/aws-solutions/serverless-image-handler/pull/426)
 - github workflows for running unit test, eslint and prettier formatting, cdk nag, security scans [#402](https://github.com/aws-solutions/serverless-image-handler/pull/402)
 - demo-ui unicode support [#416](https://github.com/aws-solutions/serverless-image-handler/issues/416)
+- support for multiple cloudformation stack deployments in the same region
 
 ### Changed
 

--- a/source/constructs/lib/common-resources/common-resources-construct.ts
+++ b/source/constructs/lib/common-resources/common-resources-construct.ts
@@ -93,7 +93,7 @@ export class CommonResources extends Construct {
     const applicationType = "AWS-Solutions";
 
     const application = new appreg.Application(stack, "AppRegistry", {
-      applicationName: Fn.join("-", [Aws.STACK_NAME, Aws.REGION, Aws.ACCOUNT_ID]),
+      applicationName: Fn.join("-", ["AppRegistry", Aws.STACK_NAME, Aws.REGION, Aws.ACCOUNT_ID]),
       description: `Service Catalog application to track and manage all your resources for the solution ${props.applicationName}`,
     });
     application.associateStack(stack);
@@ -104,7 +104,7 @@ export class CommonResources extends Construct {
     Tags.of(application).add("Solutions:ApplicationType", applicationType);
 
     const attributeGroup = new appreg.AttributeGroup(stack, "DefaultApplicationAttributes", {
-      attributeGroupName: Aws.STACK_NAME,
+      attributeGroupName: `AppRegistry-${Aws.STACK_NAME}`,
       description: "Attribute group for solution information",
       attributes: {
         applicationType,

--- a/source/constructs/lib/common-resources/common-resources-construct.ts
+++ b/source/constructs/lib/common-resources/common-resources-construct.ts
@@ -93,7 +93,7 @@ export class CommonResources extends Construct {
     const applicationType = "AWS-Solutions";
 
     const application = new appreg.Application(stack, "AppRegistry", {
-      applicationName: Fn.join("-", [props.applicationName, Aws.REGION, Aws.ACCOUNT_ID]),
+      applicationName: Fn.join("-", [Aws.STACK_NAME, Aws.REGION, Aws.ACCOUNT_ID]),
       description: `Service Catalog application to track and manage all your resources for the solution ${props.applicationName}`,
     });
     application.associateStack(stack);

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -333,7 +333,9 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
           "Fn::Join": [
             "-",
             [
-              "sih",
+              {
+                "Ref": "AWS::StackName",
+              },
               {
                 "Ref": "AWS::Region",
               },

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -333,6 +333,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
           "Fn::Join": [
             "-",
             [
+              "AppRegistry",
               {
                 "Ref": "AWS::StackName",
               },
@@ -1825,7 +1826,15 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
         },
         "Description": "Attribute group for solution information",
         "Name": {
-          "Ref": "AWS::StackName",
+          "Fn::Join": [
+            "",
+            [
+              "AppRegistry-",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
         },
         "Tags": {
           "SolutionId": "S0ABC",


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->



**Description of changes:**
<!-- Please describe the changes you made -->
Add support for multiple stack deployments in the account, region with different Service Catalog AppRegistry Application

**Checklist**
- [X] :wave: I have added unit tests for all code changes.
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
