### PR TITLE
add support for CloudFront logging to s3 object ownership changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2023-04-14
+
+### Changed
+
+- added s3 bucket ownership control permission and ownership parameter to S3 logging bucket to account for [changes in S3 default behavior](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-faq.html)
+- changed xml2js version to 0.5.0
+
 ## [6.1.1] - 2023-02-09
 
 ### Added

--- a/source/constructs/lib/common-resources/custom-resources/custom-resource-construct.ts
+++ b/source/constructs/lib/common-resources/custom-resources/custom-resource-construct.ts
@@ -84,6 +84,7 @@ export class CustomResourcesConstruct extends Construct {
                 "s3:GetObject",
                 "s3:PutObject",
                 "s3:ListBucket",
+                "s3:PutBucketOwnershipControls",
               ],
               resources: [
                 Stack.of(this).formatArn({

--- a/source/constructs/package-lock.json
+++ b/source/constructs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "constructs",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "constructs",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "Apache-2.0",
       "bin": {
         "constructs": "bin/constructs.js"

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructs",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Serverless Image Handler Constructs",
   "license": "Apache-2.0",
   "bin": {

--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -1581,6 +1581,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
                     "s3:GetObject",
                     "s3:PutObject",
                     "s3:ListBucket",
+                    "s3:PutBucketOwnershipControls",
                   ],
                   "Effect": "Allow",
                   "Resource": {

--- a/source/custom-resource/index.ts
+++ b/source/custom-resource/index.ts
@@ -618,6 +618,7 @@ async function createCloudFrontLoggingBucket(requestProperties: CreateLoggingBuc
     const createBucketRequestParams: CreateBucketRequest = {
       Bucket: bucketName,
       ACL: "log-delivery-write",
+      ObjectOwnership: "ObjectWriter",
     };
     await s3Client.createBucket(createBucketRequestParams).promise();
 

--- a/source/custom-resource/package-lock.json
+++ b/source/custom-resource/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "custom-resource",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "custom-resource",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.0.0",
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1297.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1297.0.tgz",
-      "integrity": "sha512-hZbG8tfluU2ijCCBQnQzCiPbArFtaWqAUFAWAGZ0+Df7OzTm7ya9fLYV3j3L6p2PacAyAuxXaeMbgMHlHi/D3w==",
+      "version": "2.1358.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1358.0.tgz",
+      "integrity": "sha512-ZolqFlnm0mDNgub7FGrVi7r5A1rw+58zZziKhlis3IxOtIpHdx4BQU5pH4htAMuD0Ct557p/dC/wmnZH/1Rc9Q==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1272,7 +1272,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -4065,19 +4065,22 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -5133,9 +5136,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1297.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1297.0.tgz",
-      "integrity": "sha512-hZbG8tfluU2ijCCBQnQzCiPbArFtaWqAUFAWAGZ0+Df7OzTm7ya9fLYV3j3L6p2PacAyAuxXaeMbgMHlHi/D3w==",
+      "version": "2.1358.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1358.0.tgz",
+      "integrity": "sha512-ZolqFlnm0mDNgub7FGrVi7r5A1rw+58zZziKhlis3IxOtIpHdx4BQU5pH4htAMuD0Ct557p/dC/wmnZH/1Rc9Q==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -5147,7 +5150,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "dependencies": {
         "uuid": {
@@ -7175,19 +7178,19 @@
       }
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "y18n": {

--- a/source/custom-resource/package.json
+++ b/source/custom-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-resource",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "private": true,
   "description": "Serverless Image Handler custom resource",
   "license": "Apache-2.0",

--- a/source/image-handler/package-lock.json
+++ b/source/image-handler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-handler",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "image-handler",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "color": "4.2.3",
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1281.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1281.0.tgz",
-      "integrity": "sha512-nrDezd78ebYSI58iGTxNR5j6l/beYAGO0pAPMITg/Ili6SUCIGL3359fv2gxhVOI2NIwOsKs5/Mjr83+6G+zCQ==",
+      "version": "2.1358.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1358.0.tgz",
+      "integrity": "sha512-ZolqFlnm0mDNgub7FGrVi7r5A1rw+58zZziKhlis3IxOtIpHdx4BQU5pH4htAMuD0Ct557p/dC/wmnZH/1Rc9Q==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1296,7 +1296,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -4416,19 +4416,22 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -5506,9 +5509,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1281.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1281.0.tgz",
-      "integrity": "sha512-nrDezd78ebYSI58iGTxNR5j6l/beYAGO0pAPMITg/Ili6SUCIGL3359fv2gxhVOI2NIwOsKs5/Mjr83+6G+zCQ==",
+      "version": "2.1358.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1358.0.tgz",
+      "integrity": "sha512-ZolqFlnm0mDNgub7FGrVi7r5A1rw+58zZziKhlis3IxOtIpHdx4BQU5pH4htAMuD0Ct557p/dC/wmnZH/1Rc9Q==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -5520,7 +5523,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       }
     },
     "babel-jest": {
@@ -7792,19 +7795,19 @@
       }
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "y18n": {

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-handler",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "private": true,
   "description": "A Lambda function for performing on-demand image edits and manipulations.",
   "license": "Apache-2.0",

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "source",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "private": true,
   "description": "ESLint and prettier dependencies to be used within the solution",
   "license": "Apache-2.0",

--- a/source/solution-utils/package-lock.json
+++ b/source/solution-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solution-utils",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solution-utils",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.1.1",

--- a/source/solution-utils/package.json
+++ b/source/solution-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solution-utils",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "private": true,
   "description": "Utilities to be used within this solution",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Description of changes:**
A recent change was made regarding the default S3 bucket and object ownership configuration. This impacted the CloudFront S3 Logging bucket that is created by the custom resource Lambda which caused the deployment to fail.
Configuration changes associated with the bucket creation were necessary.

The announcement for the Amazon S3 change can be found at [https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/)

Changes

* version update to 6.1.2
* custom resource Lambda IAM policy permission addition
* custom resource Lambda createBucket property addition
* xml2js version update to address github dependabot alerts

**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
