### PR TITLE
fix: AUTO_WEBP should work if `accept` header is lowercase

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -427,8 +427,9 @@ export class ImageRequest {
    */
   public getOutputFormat(event: ImageHandlerEvent, requestType: RequestTypes = undefined): ImageFormatTypes {
     const { AUTO_WEBP } = process.env;
+    const accept = event.headers.Accept || event.headers.accept;
 
-    if (AUTO_WEBP === "Yes" && event.headers.Accept && event.headers.Accept.includes(ContentTypes.WEBP)) {
+    if (AUTO_WEBP === "Yes" && accept && accept.includes(ContentTypes.WEBP)) {
       return ImageFormatTypes.WEBP;
     } else if (requestType === RequestTypes.DEFAULT) {
       const decoded = this.decodeRequest(event);

--- a/source/image-handler/test/image-request/get-output-format.spec.ts
+++ b/source/image-handler/test/image-request/get-output-format.spec.ts
@@ -21,11 +21,29 @@ describe("getOutputFormat", () => {
     process.env = OLD_ENV;
   });
 
-  it('Should pass if it returns "webp" for an accepts header which includes webp', () => {
+  it('Should pass if it returns "webp" for a capitalized accepts header which includes webp', () => {
     // Arrange
     const event = {
       headers: {
         Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3",
+      },
+    };
+    process.env.AUTO_WEBP = "Yes";
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.getOutputFormat(event);
+
+    // Assert
+    expect(result).toEqual("webp");
+  });
+
+  it('Should pass if it returns "webp" for a lowercase accepts header which includes webp', () => {
+    // Arrange
+    const event = {
+      headers: {
+        accept:
           "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3",
       },
     };


### PR DESCRIPTION
**Issue #, if available:** #467 

**Description of changes:**

AUTO_WEBP should work if `accept` header is lowercase

Refs: https://github.com/aws/aws-sam-cli/issues/3083#issuecomment-887632702

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
