### PR TITLE
Fix animation not preserved to GIFs in case of AUTO_WEBP

### DIFF
--- a/source/constructs/test/__snapshots__/constructs.test.ts.snap
+++ b/source/constructs/test/__snapshots__/constructs.test.ts.snap
@@ -1150,7 +1150,7 @@ exports[`Serverless Image Handler Stack Snapshot 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "41ef15a3e6b6b8f15863cb611acea96ea2fc7691ede4f30e039824930c06e3ef.zip",
+          "S3Key": "0d34710eeb4659e4f7f2b33f1083ac6db94fb42834e94ca30fc5deccd2fb599e.zip",
         },
         "Description": "sih (v6.2.2): Performs image edits and manipulations",
         "Environment": {

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -75,7 +75,8 @@ export class ImageHandler {
    */
   async process(imageRequestInfo: ImageRequestInfo): Promise<string> {
     const { originalImage, edits } = imageRequestInfo;
-    const options = { failOnError: false, animated: imageRequestInfo.contentType === ContentTypes.GIF };
+    const supportsAnimation = imageRequestInfo.contentType === ContentTypes.GIF || imageRequestInfo.contentType === ContentTypes.WEBP;
+    const options = { failOnError: false, animated: supportsAnimation  };
     let base64EncodedImage = "";
 
     // Apply edits if specified


### PR DESCRIPTION
**Issue #456**


**Description of changes:**
Add WEBP ContentTypes.WEBP to list of formats that supports animation (and should preserve animation on compressed image)


**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [x] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
