### PR TITLE
Feat/thumbor bucket in url

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -299,7 +299,6 @@ export class ImageRequest {
 
       return decodeURIComponent(
         path
-          .replace(`/${bucket}`, '')
           .replace(/\/\d+x\d+:\d+x\d+(?=\/)/g, "")
           .replace(/\/\d+x\d+(?=\/)/g, "")
           .replace(/filters:watermark\(.*\)/u, "")
@@ -307,6 +306,7 @@ export class ImageRequest {
           .replace(/\/fit-in(?=\/)/g, "")
           .replace(/^\/+/g, "")
           .replace(/^\/+/, "")
+          .replace(new RegExp(bucket + "\/"), '')
       );
     }
 

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -101,7 +101,7 @@ export class ImageRequest {
 
       imageRequestInfo.requestType = this.parseRequestType(event);
       imageRequestInfo.bucket = this.parseImageBucket(event, imageRequestInfo.requestType);
-      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType, bucket);
+      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType, imageRequestInfo.bucket);
       imageRequestInfo.edits = this.parseImageEdits(event, imageRequestInfo.requestType);
 
       const originalImage = await this.getOriginalImage(imageRequestInfo.bucket, imageRequestInfo.key);
@@ -272,7 +272,7 @@ export class ImageRequest {
    * @param requestType Type of the request.
    * @returns The name of the appropriate Amazon S3 key.
    */
-  public parseImageKey(event: ImageHandlerEvent, requestType: RequestTypes, bucket: string): string {
+  public parseImageKey(event: ImageHandlerEvent, requestType: RequestTypes, bucket: string = null): string {
     if (requestType === RequestTypes.DEFAULT) {
       // Decode the image request and return the image key
       const { key } = this.decodeRequest(event);

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -224,7 +224,10 @@ export class ImageRequest {
       // Use the default image source bucket env var
       const sourceBuckets = this.getAllowedSourceBuckets();
       // Take the path and split it at "/" to get each "word" in the url as array
-      let potentialBucket = event.path.split("/");
+      let potentialBucket = event.path
+        .split("/")
+        .filter(e => e.startsWith('s3:'))
+        .map(e => e.replace("s3:", ""));
       // filter out all parts that are not an bucket-url
       potentialBucket = potentialBucket.filter(e => sourceBuckets.includes(e));
       // return the first match
@@ -306,7 +309,7 @@ export class ImageRequest {
           .replace(/\/fit-in(?=\/)/g, "")
           .replace(/^\/+/g, "")
           .replace(/^\/+/, "")
-          .replace(new RegExp(bucket + "\/"), '')
+          .replace(new RegExp("s3:" + bucket + "\/"), '')
       );
     }
 

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -223,6 +223,13 @@ export class ImageRequest {
     } else if (requestType === RequestTypes.THUMBOR || requestType === RequestTypes.CUSTOM) {
       // Use the default image source bucket env var
       const sourceBuckets = this.getAllowedSourceBuckets();
+      // Take the path and split it at "/" to get each "word" in the url as array
+      let potentialBucket = event.path.split("/");
+      // filter out all parts that are not an bucket-url
+      potentialBucket = potentialBucket.filter(e => sourceBuckets.includes(e));
+      // return the first match
+      if (potentialBucket.length > 0) return potentialBucket[0];
+
       return sourceBuckets[0];
     } else {
       throw new ImageHandlerError(

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -101,7 +101,7 @@ export class ImageRequest {
 
       imageRequestInfo.requestType = this.parseRequestType(event);
       imageRequestInfo.bucket = this.parseImageBucket(event, imageRequestInfo.requestType);
-      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType);
+      imageRequestInfo.key = this.parseImageKey(event, imageRequestInfo.requestType, bucket);
       imageRequestInfo.edits = this.parseImageEdits(event, imageRequestInfo.requestType);
 
       const originalImage = await this.getOriginalImage(imageRequestInfo.bucket, imageRequestInfo.key);
@@ -272,7 +272,7 @@ export class ImageRequest {
    * @param requestType Type of the request.
    * @returns The name of the appropriate Amazon S3 key.
    */
-  public parseImageKey(event: ImageHandlerEvent, requestType: RequestTypes): string {
+  public parseImageKey(event: ImageHandlerEvent, requestType: RequestTypes, bucket: string): string {
     if (requestType === RequestTypes.DEFAULT) {
       // Decode the image request and return the image key
       const { key } = this.decodeRequest(event);
@@ -299,6 +299,7 @@ export class ImageRequest {
 
       return decodeURIComponent(
         path
+          .replace(`/${bucket}`, '')
           .replace(/\/\d+x\d+:\d+x\d+(?=\/)/g, "")
           .replace(/\/\d+x\d+(?=\/)/g, "")
           .replace(/filters:watermark\(.*\)/u, "")

--- a/source/image-handler/test/image-request/parse-image-bucket.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-bucket.spec.ts
@@ -129,7 +129,7 @@ describe("parseImageBucket", () => {
 
   it("should parse bucket-name from first part in thumbor request but fail since it's not allowed", () => {
     // Arrange
-    const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
+    const event = { path: "/filters:grayscale()/s3:test-bucket/test-image-001.jpg" };
     process.env.SOURCE_BUCKETS = "allowedBucket001, allowedBucket002";
 
     // Act
@@ -142,7 +142,7 @@ describe("parseImageBucket", () => {
 
   it("should parse bucket-name from first part in thumbor request and return it", () => {
     // Arrange
-    const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
+    const event = { path: "/filters:grayscale()/s3:test-bucket/test-image-001.jpg" };
     process.env.SOURCE_BUCKETS = "allowedBucket001, test-bucket";
 
     // Act

--- a/source/image-handler/test/image-request/parse-image-bucket.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-bucket.spec.ts
@@ -127,7 +127,7 @@ describe("parseImageBucket", () => {
     }
   });
 
-  it("should parse bucket-name from first part in thubor request but fail since it's not allowed", () => {
+  it("should parse bucket-name from first part in thumbor request but fail since it's not allowed", () => {
     // Arrange
     const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
     process.env.SOURCE_BUCKETS = "allowedBucket001, allowedBucket002";
@@ -151,5 +151,18 @@ describe("parseImageBucket", () => {
     const bucket = imageRequest.parseImageBucket(event, RequestTypes.THUMBOR);
     // Assert
     expect(bucket).toEqual("test-bucket")
+  })
+
+  it("should take bucket-name from env-variable if not present in the URL", () => {
+    // Arrange
+    const event = { path: "/filters:grayscale()/test-image-001.jpg" };
+    process.env.SOURCE_BUCKETS = "allowedBucket001, test-bucket";
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+
+    const bucket = imageRequest.parseImageBucket(event, RequestTypes.THUMBOR);
+    // Assert
+    expect(bucket).toEqual("allowedBucket001")
   })
 });

--- a/source/image-handler/test/image-request/parse-image-bucket.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-bucket.spec.ts
@@ -126,4 +126,30 @@ describe("parseImageBucket", () => {
       });
     }
   });
+
+  it("should parse bucket-name from first part in thubor request but fail since it's not allowed", () => {
+    // Arrange
+    const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
+    process.env.SOURCE_BUCKETS = "allowedBucket001, allowedBucket002";
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+
+    const bucket = imageRequest.parseImageBucket(event, RequestTypes.THUMBOR);
+    // Assert
+    expect(bucket).toEqual("allowedBucket001")
+  })
+
+  it("should parse bucket-name from first part in thubor request and return it", () => {
+    // Arrange
+    const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
+    process.env.SOURCE_BUCKETS = "allowedBucket001, test-bucket";
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+
+    const bucket = imageRequest.parseImageBucket(event, RequestTypes.THUMBOR);
+    // Assert
+    expect(bucket).toEqual("test-bucket")
+  })
 });

--- a/source/image-handler/test/image-request/parse-image-bucket.spec.ts
+++ b/source/image-handler/test/image-request/parse-image-bucket.spec.ts
@@ -140,7 +140,7 @@ describe("parseImageBucket", () => {
     expect(bucket).toEqual("allowedBucket001")
   })
 
-  it("should parse bucket-name from first part in thubor request and return it", () => {
+  it("should parse bucket-name from first part in thumbor request and return it", () => {
     // Arrange
     const event = { path: "/filters:grayscale()/test-bucket/test-image-001.jpg" };
     process.env.SOURCE_BUCKETS = "allowedBucket001, test-bucket";


### PR DESCRIPTION
Hello,

currently when using Thumbor-Style URLs (which is the only way to get readable URLs for SEO) you cannot specify the bucket which will get used. Currently always the first one provided via Env-Settings will be used.

My suggestion is to check if the URL contains any allowed bucket, and if it does, use that one. This would mean one can - but doesn't need to - add the bucket to the URL. If left empty it would not break existing setups.

e.g:
SOURCE_BUCKETS: "test1, test2"
Request: "/fit-in/my-image.jpg"
This would currently load "my-image.jpg" from the bucket "test1".

With my PR you can do "/fit-in/test2/my-image.jpg" which would load from test2.

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
