### PR TITLE
feat: Include and handle ETag/If-None-Match header

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -23,6 +23,7 @@ type OriginalImageInfo = Partial<{
   contentType: string;
   expires: string;
   lastModified: string;
+  eTag: string;
   cacheControl: string;
   originalImage: Buffer;
 }>;
@@ -174,6 +175,10 @@ export class ImageRequest {
 
       if (originalImage.LastModified) {
         result.lastModified = new Date(originalImage.LastModified).toUTCString();
+      }
+
+      if (originalImage.ETag) {
+        result.eTag = originalImage.ETag;
       }
 
       result.cacheControl = originalImage.CacheControl ?? "max-age=31536000,public";

--- a/source/image-handler/lib/enums.ts
+++ b/source/image-handler/lib/enums.ts
@@ -3,6 +3,7 @@
 
 export enum StatusCodes {
   OK = 200,
+  NOT_MODIFIED = 304,
   BAD_REQUEST = 400,
   FORBIDDEN = 403,
   NOT_FOUND = 404,

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -48,6 +48,7 @@ export interface ImageRequestInfo {
   contentType?: string;
   expires?: string;
   lastModified?: string;
+  eTag?: string;
   cacheControl?: string;
   outputFormat?: ImageFormatTypes;
   effort?: number;


### PR DESCRIPTION
Extend the existing functionality to check if the If-None-Match header matches the original ETag value.

**Issue #, if available:**
https://github.com/aws-solutions/serverless-image-handler/issues/328

Original PR: https://github.com/aws-solutions/serverless-image-handler/pull/329

**Description of changes:**
### Changes Made
This pull request introduces enhancements to the caching mechanism by including and handling the ETag/If-None-Match header in the response headers. The primary objective is to leverage the efficiency of browser caching, allowing for more streamlined network traffic.

### Benefits
- **Efficient Browser Caching:** Inclusion of the ETag header facilitates efficient browser caching.
- **Reduced Network Traffic:** Use of the If-None-Match header enables the server to respond with a 304 Not Modified when the image remains unchanged, reducing the need to resend content.

### Considerations
- **Handling Modified Versions:** Acknowledging the importance of tracking modified/manipulated image versions, the initial approach using only the ETag value from the original request might not cover all use cases.

- **Using only the Original ETag value:** The reason to use only the ETag from the Original Image may be sufficient because the dependency of the browser cache on the URL from which the image is requested is addressed. Image manipulations, often carried out through request parameters, lead to distinct cache versions, even when utilizing the same ETag header.

- **Proposal:** Consideration is given to using the ETag header for the original source image consistently, potentially simplifying the handling of cache versions.


**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
