### PR TITLE
Default image now respects cache-control headers

### DIFF
--- a/source/image-handler/index.ts
+++ b/source/image-handler/index.ts
@@ -75,7 +75,7 @@ export async function handler(event: ImageHandlerEvent): Promise<ImageHandlerExe
         const headers = getResponseHeaders(false, isAlb);
         headers["Content-Type"] = defaultFallbackImage.ContentType;
         headers["Last-Modified"] = defaultFallbackImage.LastModified;
-        headers["Cache-Control"] = "max-age=31536000,public";
+        headers["Cache-Control"] = defaultFallbackImage.CacheControl ?? "max-age=31536000,public";
 
         return {
           statusCode: error.status ? error.status : StatusCodes.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
**Issue #, if available:**
#563


**Description of changes:**
The default image now respects cache control headers if set. Otherwise default to "max-age=31536000,public".
Changes have been deployed and tested. Works as intended and solves #563 


**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :wave: I have added unit tests for all code changes.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
