### PR TITLE
updated documenation regarding multiple bucket access

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,27 @@ overrideWarningsEnabled=false npx cdk deploy\
 ```
 
 _Note:_
-- **MY_BUCKET**: name of an existing bucket in your account
+- **MY_BUCKET**: name of an existing bucket or the list of comma-separated bucket names in your account
 - **PROFILE_NAME**: name of an AWS CLI profile that has appropriate credentials for deploying in your preferred region
+
+Check the bucket resource policy if the API cannot access the bucket after the successful deployment. You may need to allow **s3:GetObject** and **s3:ListBucket** operations for your the Image Handler lambda role:
+
+```json
+{
+    "Effect": "Allow",
+    "Principal": {
+        "AWS": "arn:aws:iam::XXXXXX:role/ServerlessImageHandlerSta-BackEndImageHandlerFuncti-XXXXXX"
+    },
+    "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+    ],
+    "Resource": [
+        "arn:aws:s3:::XXXXXX-bucket",
+        "arn:aws:s3:::XXXXXX-bucket/*"
+    ]
+}
+```
 
 # Collection of operational metrics
 


### PR DESCRIPTION
**Issue #, if available:**
The documentation does not mention that it is possible to provide access to multiple buckets



**Description of changes:**
- Added the note about multiple bucket access
- Added note regarding S3 bucket resource policy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
