### PR TITLE
Changing the instantiation method for Sharp in the image processing logic

### DIFF
--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -103,7 +103,10 @@ export class ImageHandler {
     } else {
       if (imageRequestInfo.outputFormat !== undefined) {
         // convert image to Sharp and change output format if specified
-        const modifiedImage = this.modifyImageOutput( await this.instantiateSharpImage(originalImage,{}, options), imageRequestInfo);
+        const modifiedImage = this.modifyImageOutput(
+          await this.instantiateSharpImage(originalImage, {}, options),
+          imageRequestInfo
+        );
         // convert to base64 encoded string
         const imageBuffer = await modifiedImage.toBuffer();
         base64EncodedImage = imageBuffer.toString("base64");

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -103,7 +103,7 @@ export class ImageHandler {
     } else {
       if (imageRequestInfo.outputFormat !== undefined) {
         // convert image to Sharp and change output format if specified
-        const modifiedImage = this.modifyImageOutput(sharp(originalImage, options), imageRequestInfo);
+        const modifiedImage = this.modifyImageOutput( await this.instantiateSharpImage(originalImage,{}, options), imageRequestInfo);
         // convert to base64 encoded string
         const imageBuffer = await modifiedImage.toBuffer();
         base64EncodedImage = imageBuffer.toString("base64");


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
#578


**Description of changes:**
<!-- Please describe the changes you made -->
I fixed the issue where the image metadata, especially orientation, was lost when outputFormat was set and AutoWebPParameter=Yes was used. The change ensures that the EXIF metadata is preserved during the WebP conversion process.

**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
